### PR TITLE
Implement TabPanel navigation

### DIFF
--- a/wp-content/plugins/bimbeau-multisteps/assets/js/admin-tabs.js
+++ b/wp-content/plugins/bimbeau-multisteps/assets/js/admin-tabs.js
@@ -1,0 +1,30 @@
+(function(wp){
+    const { createElement, render } = wp.element;
+    const { TabPanel } = wp.components;
+
+    document.addEventListener('DOMContentLoaded', function(){
+        const container = document.getElementById('bimbeau-ms-admin-tabs');
+        if(!container){
+            return;
+        }
+        const tabs = JSON.parse(container.dataset.tabs);
+        const current = container.dataset.current;
+        const panelTabs = tabs.map(tab => ({ name: tab.slug, title: tab.label }));
+
+        const onSelect = (name) => {
+            const tab = tabs.find(t => t.slug === name);
+            if(tab){
+                window.location = tab.url;
+            }
+        };
+
+        render(
+            createElement(TabPanel, {
+                tabs: panelTabs,
+                onSelect,
+                initialTabName: current,
+            }),
+            container
+        );
+    });
+})(window.wp);

--- a/wp-content/plugins/bimbeau-multisteps/assets/js/email-tabs.js
+++ b/wp-content/plugins/bimbeau-multisteps/assets/js/email-tabs.js
@@ -1,0 +1,32 @@
+(function(wp){
+    const { createElement, render } = wp.element;
+    const { TabPanel } = wp.components;
+
+    document.addEventListener('DOMContentLoaded', function(){
+        const container = document.getElementById('bimbeau-ms-email-tabs');
+        if (!container) {
+            return;
+        }
+        const tabs = JSON.parse(container.dataset.tabs);
+        const current = container.dataset.current;
+        const panelContainer = container.querySelector('.tab-panel-container');
+        const tabContents = container.querySelectorAll('.email-tab');
+
+        function showTab(name) {
+            tabContents.forEach(div => {
+                div.style.display = div.dataset.slug === name ? 'block' : 'none';
+            });
+        }
+
+        render(
+            createElement(TabPanel, {
+                tabs: tabs.map(t => ({ name: t.slug, title: t.title })),
+                onSelect: showTab,
+                initialTabName: current,
+            }),
+            panelContainer
+        );
+
+        showTab(current);
+    });
+})(window.wp);

--- a/wp-content/plugins/bimbeau-multisteps/includes/admin/admin-settings.php
+++ b/wp-content/plugins/bimbeau-multisteps/includes/admin/admin-settings.php
@@ -75,13 +75,17 @@ function bimbeau_ms_admin_tabs($current) {
         'bimbeau-ms-steps'     => 'Gérer les étapes',
         'bimbeau-ms-labels'    => 'Messages personnalisés',
     ];
-    echo '<h2 class="nav-tab-wrapper">';
+
+    $data = [];
     foreach ($tabs as $slug => $label) {
-        $class = 'nav-tab' . ($current === $slug ? ' nav-tab-active' : '');
-        $url   = admin_url('admin.php?page=' . $slug);
-        echo '<a href="' . esc_url($url) . '" class="' . esc_attr($class) . '">' . esc_html($label) . '</a>';
+        $data[] = [
+            'slug'  => $slug,
+            'label' => $label,
+            'url'   => admin_url('admin.php?page=' . $slug),
+        ];
     }
-    echo '</h2>';
+
+    echo '<div id="bimbeau-ms-admin-tabs" data-current="' . esc_attr($current) . '" data-tabs="' . esc_attr(wp_json_encode($data)) . '"></div>';
 }
 
 /**
@@ -127,9 +131,27 @@ function bimbeau_ms_enqueue_labels_app() {
     wp_enqueue_style( 'wp-components' );
 }
 add_action( 'admin_enqueue_scripts', function( $hook ) {
-    // Apply the wp-components style to every admin page of the plugin
+    // Apply the wp-components style and admin tabs script to every plugin page
     if ( strpos( $hook, 'bimbeau-ms-' ) !== false ) {
         wp_enqueue_style( 'wp-components' );
+        wp_enqueue_script(
+            'bimbeau-ms-admin-tabs',
+            BIMBEAU_MS_URL . 'assets/js/admin-tabs.js',
+            [ 'wp-element', 'wp-components' ],
+            '1.0.0',
+            true
+        );
+    }
+
+    // Load the TabPanel handler on the emails page
+    if ( strpos( $hook, 'bimbeau-ms-emails' ) !== false ) {
+        wp_enqueue_script(
+            'bimbeau-ms-email-tabs',
+            BIMBEAU_MS_URL . 'assets/js/email-tabs.js',
+            [ 'wp-element', 'wp-components' ],
+            '1.0.0',
+            true
+        );
     }
 
 
@@ -396,77 +418,77 @@ function bimbeau_ms_email_page() {
     }
 
     ?>
-    <div class="wrap">
-        <h1>Emails</h1>
-        <?php bimbeau_ms_admin_tabs('bimbeau-ms-emails'); ?>
-        <p>Utilisez les raccourcis {prenom}, {nom}, {date} et {details} pour insérer les valeurs correspondantes.</p>
-        <h2 class="nav-tab-wrapper">
-            <a href="?page=bimbeau-ms-emails&tab=confirmation" class="nav-tab <?php echo $active_tab == 'confirmation' ? 'nav-tab-active' : ''; ?>">Confirmation</a>
-            <?php if ($enable_delay) : ?>
-                <a href="?page=bimbeau-ms-emails&tab=rappel" class="nav-tab <?php echo $active_tab == 'rappel' ? 'nav-tab-active' : ''; ?>">Rappel</a>
-            <?php endif; ?>
-        </h2>
-        <form method="post">
-            <?php if ($active_tab === 'confirmation') : ?>
-                <h2>Confirmation Client</h2>
-                <table class="form-table" role="presentation">
-                    <tr>
-                        <th scope="row"><label for="confirm_client_subject">Sujet</label></th>
-                        <td><input type="text" id="confirm_client_subject" name="confirm_client_subject" value="<?php echo esc_attr($confirmClientSubject); ?>" class="regular-text" style="width:40em;" /></td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="confirm_client_body">Corps</label></th>
-                        <td><?php wp_editor($confirmClientBody, 'confirm_client_body_editor', ['textarea_name' => 'confirm_client_body']); ?></td>
-                    </tr>
-                </table>
+        <div class="wrap">
+            <h1>Emails</h1>
+            <?php bimbeau_ms_admin_tabs('bimbeau-ms-emails'); ?>
+            <p>Utilisez les raccourcis {prenom}, {nom}, {date} et {details} pour inserer les valeurs correspondantes.</p>
 
-                <h2>Confirmation Admin</h2>
-                <table class="form-table" role="presentation">
-                    <tr>
-                        <th scope="row"><label for="confirm_admin_subject">Sujet</label></th>
-                        <td><input type="text" id="confirm_admin_subject" name="confirm_admin_subject" value="<?php echo esc_attr($confirmAdminSubject); ?>" class="regular-text" style="width:40em;" /></td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="confirm_admin_body">Corps</label></th>
-                        <td><?php wp_editor($confirmAdminBody, 'confirm_admin_body_editor', ['textarea_name' => 'confirm_admin_body']); ?></td>
-                    </tr>
-                </table>
-            <?php elseif ($active_tab === 'rappel') : ?>
-                <?php if ($enable_delay) : ?>
-                    <h2>Rappel Admin</h2>
-                    <table class="form-table" role="presentation">
-                        <tr>
-                            <th scope="row"><label for="reminder_admin_subject">Sujet</label></th>
-                            <td><input type="text" id="reminder_admin_subject" name="reminder_admin_subject" value="<?php echo esc_attr($reminderAdminSubject); ?>" class="regular-text" style="width:40em;" /></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="reminder_admin_body">Corps</label></th>
-                            <td><?php wp_editor($reminderAdminBody, 'reminder_admin_body_editor', ['textarea_name' => 'reminder_admin_body']); ?></td>
-                        </tr>
-                    </table>
+            <?php
+            $tabs_data = [ [ 'slug' => 'confirmation', 'title' => 'Confirmation' ] ];
+            if ( $enable_delay ) {
+                $tabs_data[] = [ 'slug' => 'rappel', 'title' => 'Rappel' ];
+            }
+            ?>
+            <div id="bimbeau-ms-email-tabs" data-current="<?php echo esc_attr( $active_tab ); ?>" data-tabs="<?php echo esc_attr( wp_json_encode( $tabs_data ) ); ?>">
+                <div class="tab-panel-container"></div>
+                <form method="post">
+                    <div class="email-tab" data-slug="confirmation">
+                        <h2>Confirmation Client</h2>
+                        <table class="form-table" role="presentation">
+                            <tr>
+                                <th scope="row"><label for="confirm_client_subject">Sujet</label></th>
+                                <td><input type="text" id="confirm_client_subject" name="confirm_client_subject" value="<?php echo esc_attr($confirmClientSubject); ?>" class="regular-text" style="width:40em;" /></td>
+                            </tr>
+                            <tr>
+                                <th scope="row"><label for="confirm_client_body">Corps</label></th>
+                                <td><?php wp_editor($confirmClientBody, 'confirm_client_body_editor', ['textarea_name' => 'confirm_client_body']); ?></td>
+                            </tr>
+                        </table>
 
-                    <h2>Programmation du rappel</h2>
-                    <table class="form-table" role="presentation">
-                        <tr>
-                            <th scope="row"><label for="reminder_days_before">Jours avant la date de réponse</label></th>
-                            <td><input type="number" id="reminder_days_before" name="reminder_days_before" min="0" value="<?php echo esc_attr($reminderDays); ?>" class="small-text" /></td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="reminder_time">Heure d'envoi</label></th>
-                            <td><input type="time" id="reminder_time" name="reminder_time" value="<?php echo esc_attr($reminderTime); ?>" /></td>
-                        </tr>
-                    </table>
-                <?php else : ?>
-                    <p><?php echo esc_html(get_option(
-                        'bimbeau_ms_msg_reminder_disabled',
-                        'La fonctionnalité de rappel est désactivée.'
-                    )); ?></p>
-                <?php endif; ?>
-            <?php endif; ?>
+                        <h2>Confirmation Admin</h2>
+                        <table class="form-table" role="presentation">
+                            <tr>
+                                <th scope="row"><label for="confirm_admin_subject">Sujet</label></th>
+                                <td><input type="text" id="confirm_admin_subject" name="confirm_admin_subject" value="<?php echo esc_attr($confirmAdminSubject); ?>" class="regular-text" style="width:40em;" /></td>
+                            </tr>
+                            <tr>
+                                <th scope="row"><label for="confirm_admin_body">Corps</label></th>
+                                <td><?php wp_editor($confirmAdminBody, 'confirm_admin_body_editor', ['textarea_name' => 'confirm_admin_body']); ?></td>
+                            </tr>
+                        </table>
+                    </div>
+                    <?php if ( $enable_delay ) : ?>
+                    <div class="email-tab" data-slug="rappel">
+                        <h2>Rappel Admin</h2>
+                        <table class="form-table" role="presentation">
+                            <tr>
+                                <th scope="row"><label for="reminder_admin_subject">Sujet</label></th>
+                                <td><input type="text" id="reminder_admin_subject" name="reminder_admin_subject" value="<?php echo esc_attr($reminderAdminSubject); ?>" class="regular-text" style="width:40em;" /></td>
+                            </tr>
+                            <tr>
+                                <th scope="row"><label for="reminder_admin_body">Corps</label></th>
+                                <td><?php wp_editor($reminderAdminBody, 'reminder_admin_body_editor', ['textarea_name' => 'reminder_admin_body']); ?></td>
+                            </tr>
+                        </table>
 
-            <p class="submit"><input type="submit" name="bimbeau_ms_save_emails" class="button button-primary" value="Enregistrer" /></p>
-        </form>
-    </div>
+                        <h2>Programmation du rappel</h2>
+                        <table class="form-table" role="presentation">
+                            <tr>
+                                <th scope="row"><label for="reminder_days_before">Jours avant la date de réponse</label></th>
+                                <td><input type="number" id="reminder_days_before" name="reminder_days_before" min="0" value="<?php echo esc_attr($reminderDays); ?>" class="small-text" /></td>
+                            </tr>
+                            <tr>
+                                <th scope="row"><label for="reminder_time">Heure d'envoi</label></th>
+                                <td><input type="time" id="reminder_time" name="reminder_time" value="<?php echo esc_attr($reminderTime); ?>" /></td>
+                            </tr>
+                        </table>
+                    </div>
+                    <?php endif; ?>
+
+                    <p class="submit"><input type="submit" name="bimbeau_ms_save_emails" class="button button-primary" value="Enregistrer" /></p>
+                </form>
+            </div>
+        </div>
     <?php
 }
 


### PR DESCRIPTION
## Summary
- use `@wordpress/components` TabPanel for email configuration
- add `email-tabs.js` script and load it on the emails page

## Testing
- `php -v` *(fails: command not found)*
- `git status --short`