### PR TITLE
Fix TabPanel navigation

### DIFF
--- a/wp-content/plugins/bimbeau-multisteps/assets/js/admin-tabs.js
+++ b/wp-content/plugins/bimbeau-multisteps/assets/js/admin-tabs.js
@@ -1,0 +1,42 @@
+(function (wp) {
+    const { createElement, render } = wp.element;
+    const { TabPanel } = wp.components;
+
+    function init() {
+        const container = document.getElementById('bimbeau-ms-admin-tabs');
+        if (!container) {
+            return;
+        }
+
+        const fallback = document.getElementById('bimbeau-ms-admin-tabs-fallback');
+        if (fallback) {
+            fallback.style.display = 'none';
+        }
+
+        const tabs = JSON.parse(container.dataset.tabs);
+        const current = container.dataset.current;
+        const panelTabs = tabs.map((tab) => ({ name: tab.slug, title: tab.label }));
+
+        const onSelect = (name) => {
+            const tab = tabs.find((t) => t.slug === name);
+            if (tab) {
+                window.location = tab.url;
+            }
+        };
+
+        render(
+            createElement(TabPanel, {
+                tabs: panelTabs,
+                onSelect,
+                initialTabName: current,
+            }),
+            container
+        );
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})(window.wp);

--- a/wp-content/plugins/bimbeau-multisteps/includes/admin/admin-settings.php
+++ b/wp-content/plugins/bimbeau-multisteps/includes/admin/admin-settings.php
@@ -75,13 +75,22 @@ function bimbeau_ms_admin_tabs($current) {
         'bimbeau-ms-steps'     => 'Gérer les étapes',
         'bimbeau-ms-labels'    => 'Messages personnalisés',
     ];
-    echo '<h2 class="nav-tab-wrapper">';
+
+    $data = [];
+    echo '<h2 id="bimbeau-ms-admin-tabs-fallback" class="nav-tab-wrapper">';
     foreach ($tabs as $slug => $label) {
         $class = 'nav-tab' . ($current === $slug ? ' nav-tab-active' : '');
         $url   = admin_url('admin.php?page=' . $slug);
         echo '<a href="' . esc_url($url) . '" class="' . esc_attr($class) . '">' . esc_html($label) . '</a>';
+        $data[] = [
+            'slug'  => $slug,
+            'label' => $label,
+            'url'   => $url,
+        ];
     }
     echo '</h2>';
+
+    echo '<div id="bimbeau-ms-admin-tabs" data-current="' . esc_attr($current) . '" data-tabs="' . esc_attr(wp_json_encode($data)) . '"></div>';
 }
 
 /**
@@ -127,9 +136,16 @@ function bimbeau_ms_enqueue_labels_app() {
     wp_enqueue_style( 'wp-components' );
 }
 add_action( 'admin_enqueue_scripts', function( $hook ) {
-    // Apply the wp-components style to every admin page of the plugin
+    // Apply the wp-components style and admin tabs script to every plugin page
     if ( strpos( $hook, 'bimbeau-ms-' ) !== false ) {
         wp_enqueue_style( 'wp-components' );
+        wp_enqueue_script(
+            'bimbeau-ms-admin-tabs',
+            BIMBEAU_MS_URL . 'assets/js/admin-tabs.js',
+            [ 'wp-element', 'wp-components' ],
+            '1.0.0',
+            true
+        );
     }
 
 


### PR DESCRIPTION
## Summary
- hide fallback tab links and render `@wordpress/components` TabPanel once the page loads
- show original nav links as a non-JS fallback

## Testing
- ❌ `php -v` (PHP not installed)
- ✅ `git status --short`
