### PR TITLE
Improve admin navigation docs and JS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ wp-content/plugins/bimbeau-multisteps/
     └── utils    # helper functions
 ```
 
+### Admin navigation
+
+Each administration page prints a placeholder for the navigation tabs.  The
+script `assets/js/admin-tabs.js` replaces this markup with Gutenberg’s
+`TabPanel` component so you can switch between dashboard pages with a single
+click.
+
 ## Email placeholders
 
 When editing email templates or labels you can use the following placeholders:

--- a/wp-content/plugins/bimbeau-multisteps/assets/js/admin-tabs.js
+++ b/wp-content/plugins/bimbeau-multisteps/assets/js/admin-tabs.js
@@ -4,14 +4,16 @@
 
     function init() {
         const container = document.getElementById('bimbeau-ms-admin-tabs');
-        if (!container) {
+        if (!container || !wp || !wp.element || !wp.components) {
             return;
         }
 
         const fallback = document.getElementById('bimbeau-ms-admin-tabs-fallback');
-        if (fallback) {
-            fallback.style.display = 'none';
-        }
+        const hideFallback = () => {
+            if (fallback) {
+                fallback.style.display = 'none';
+            }
+        };
 
         const tabs = JSON.parse(container.dataset.tabs);
         const current = container.dataset.current;
@@ -32,6 +34,8 @@
             }),
             container
         );
+
+        hideFallback();
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- document Gutenberg tab-based navigation
- ensure admin-tab JS hides fallback only after successful render

## Testing
- `find wp-content/plugins/bimbeau-multisteps -name '*.php' -print0 | xargs -0 -n1 php -l` *(fails: `php: No such file or directory`)*